### PR TITLE
Pass stdout as a second argument when error happens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ gitStatus((err, data) => {
     console.log(err || data);
     // => [ { x: ' ', y: 'M', to: 'example/index.js', from: null } ]
 });
+
+//in order to bypass LF to CRLF warnings use a wrapper
+gitStatus(gitStatus.parseWithLineEndingWarnings((err, data) => {
+    console.log('parseWithLineEndingWarnings\n', err || data);
+    // => [ { x: ' ', y: 'M', to: 'example/index.js', from: null } ]
+}));
 ```
 
 ## :memo: Documentation

--- a/example/index.js
+++ b/example/index.js
@@ -3,6 +3,11 @@
 const gitStatus = require("../lib");
 
 gitStatus((err, data) => {
-    console.log(err || data);
+    console.log('gitStatus\n', err || data);
     // => [ { x: ' ', y: 'M', to: 'example/index.js', from: null } ]
 });
+
+gitStatus(gitStatus.parseWithLineEndingWarnings((err, data) => {
+    console.log('parseWithLineEndingWarnings\n', err || data);
+    // => [ { x: ' ', y: 'M', to: 'example/index.js', from: null } ]
+}));

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,15 +16,38 @@ const spawno = require("spawno")
  * @param {Object} options The `spawno` options.
  * @param {Function} cb The callback function.
  */
-module.exports = function gitStatus (options, cb) {
-
+function gitStatus (options, cb) {
     if (typeof options === "function") {
         cb = options;
         options = {};
     }
 
     spawno("git", ["status", "--porcelain", "-z"], options, (err, stdout, stderr) => {
-        if (err || stderr) { return cb(err || stderr); }
+        if (err || stderr) { return cb(err || stderr, stdout); }
         cb(null, parse(stdout));
     });
+}
+
+/**
+ * Ignores LF to CRLF warnings and gives parsed status info
+ * @param cb {Function}
+ */
+gitStatus.parseWithLineEndingWarnings = function (cb) {
+    return function (err, result) {
+        let showStderr = err;
+        if (err && typeof err === 'string') {
+            const stderrLines = err.trim().split(/\n/);
+            const warningsAfterFilter = stderrLines.filter(line => {
+                return (line !== 'The file will have its original line endings in your working directory.' &&
+                !line.startsWith('warning: LF will be replaced by CRLF in'));
+            });
+            showStderr = warningsAfterFilter.length;
+            err = new Error(err);
+            result = parse(result);
+        }
+        if (showStderr) { return cb(err); }
+        cb(null, result);
+    }
 };
+
+module.exports = gitStatus;

--- a/package.json
+++ b/package.json
@@ -11,9 +11,15 @@
   "version": "1.0.3",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+  "contributors": [
+    "Sergey Zarouski <sergey@webuniverse.io> (http://webuniverse.io)"
+  ],
   "files": [
     "bin/",
     "app/",
@@ -39,5 +45,8 @@
     "oargv": "^3.4.2",
     "parse-git-status": "^0.1.0",
     "spawno": "^1.0.1"
+  },
+  "devDependencies": {
+    "jest": "^17.0.3"
   }
 }

--- a/test/__snapshots__/parseWithLineEndingWarnings.test.js.snap
+++ b/test/__snapshots__/parseWithLineEndingWarnings.test.js.snap
@@ -1,0 +1,45 @@
+exports[`test should parse result if only line error warnings found 1`] = `
+Array [
+  Object {
+    "from": null,
+    "to": "example/index.js",
+    "x": " ",
+    "y": "M",
+  },
+  Object {
+    "from": null,
+    "to": " lib/index.js",
+    "x": " ",
+    "y": " ",
+  },
+  Object {
+    "from": null,
+    "to": " package.json",
+    "x": " ",
+    "y": " ",
+  },
+  Object {
+    "from": null,
+    "to": " .idea/",
+    "x": " ",
+    "y": "?",
+  },
+]
+`;
+
+exports[`test should provide error if not only line error warnings found 1`] = `
+[Error: warning: LF will be replaced by CRLF in path/to/x/y.z
+The file will have its original line endings in your working directory.
+Oh snap!]
+`;
+
+exports[`test should return unchanged result if no error 1`] = `
+Array [
+  Object {
+    "from": "",
+    "to": "",
+    "x": "",
+    "y": "",
+  },
+]
+`;

--- a/test/parseWithLineEndingWarnings.test.js
+++ b/test/parseWithLineEndingWarnings.test.js
@@ -1,0 +1,33 @@
+const parseWithLineEndingWarnings = require('../lib').parseWithLineEndingWarnings;
+const gitStatusOutputSample = ' M example/index.js\0  M lib/index.js\0  M package.json\0 ?? .idea/';
+const lineEndingsError = `
+warning: LF will be replaced by CRLF in path/to/x/y.z
+The file will have its original line endings in your working directory.
+`.trim();
+test('should return unchanged result if no error', () => {
+    parseWithLineEndingWarnings((err, data) => {
+        expect(err).toBe(null);
+        expect(data).toMatchSnapshot();
+    })(null, [{x: '', y: '', to: '', from: ''}]);
+});
+
+test('should give back only an error if spawno fails', () => {
+    parseWithLineEndingWarnings((err, data) => {
+        expect(err.message).toBe('oh');
+        expect(data).toBe(undefined);
+    })(new Error('oh'), '');
+});
+
+test('should parse result if only line error warnings found', () => {
+    parseWithLineEndingWarnings((err, data) => {
+        expect(err).toBe(null);
+        expect(data).toMatchSnapshot();
+    })(lineEndingsError, gitStatusOutputSample);
+});
+
+test('should provide error if not only line error warnings found', () => {
+    parseWithLineEndingWarnings((err, data) => {
+        expect(err).toMatchSnapshot();
+        expect(data).toBe(undefined);
+    })(lineEndingsError + '\nOh snap!', gitStatusOutputSample);
+});


### PR DESCRIPTION
It is possible for git status to write to both stderr and stdout in case when there is a line ending warning, which can be [ignored](http://stackoverflow.com/questions/17628305/windows-git-warning-lf-will-be-replaced-by-crlf-is-that-warning-tail-backwar). This PR exposes stdout as a second argument of the callback even when error is not null. Also a helpful `parseWithLineEndingWarnings` method was added, so that status info can still be retrieved in case when line ending warnings exist. If other kind of warning exist, this method will return an error.